### PR TITLE
id payload of jwt fixed.

### DIFF
--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -24,7 +24,7 @@ router.post("/login", async (req, res) => {
           .json({ message: "Wrong Password", error: true });
    
     const payload = {
-      id: user._id,
+      id: user.userId,
       groups: user.group
     };
     


### PR DESCRIPTION
Previously we were passing _id which is generated by mongodb in id parameter of jwt token. Now we are passing userId set by the user to the id parameter of the token.